### PR TITLE
feat: 예약 카드에 방문 확정 버튼 추가

### DIFF
--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -49,6 +49,7 @@ function ReservationCard({
   reservation,
   onCancel,
   onMarkVisited,
+  isMarkingVisited,
   onWriteReview,
   onEditReview,
   isReviewed,
@@ -56,6 +57,7 @@ function ReservationCard({
   reservation: Reservation;
   onCancel: (id: number) => void;
   onMarkVisited: (id: number) => void;
+  isMarkingVisited: boolean;
   onWriteReview: (reservation: Reservation) => void;
   onEditReview: (reservation: Reservation) => void;
   isReviewed: boolean;
@@ -108,12 +110,15 @@ function ReservationCard({
       {/* 액션 버튼 */}
       {isUpcoming && (
         <div className="mt-4 flex flex-col gap-2">
-          <button
-            onClick={() => onMarkVisited(reservation.id)}
-            className="w-full rounded-lg bg-orange-500 py-2 text-sm font-medium text-white hover:bg-orange-600"
-          >
-            방문 확정
-          </button>
+          {reservation.status === 'CONFIRMED' && (
+            <button
+              onClick={() => onMarkVisited(reservation.id)}
+              disabled={isMarkingVisited}
+              className="w-full rounded-lg bg-orange-500 py-2 text-sm font-medium text-white hover:bg-orange-600 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isMarkingVisited ? '처리 중...' : '방문 확정'}
+            </button>
+          )}
           <div className="flex gap-2">
             <button
               onClick={() =>
@@ -176,7 +181,7 @@ export default function ReservationsPage() {
   const userId = useAuthStore((s) => s.userId) ?? 0;
   const { data: reservations = [], isLoading } = useReservationsQuery();
   const { mutate: cancelReservation } = useCancelReservationMutation();
-  const { mutate: markVisited } = useMarkVisitedMutation();
+  const { mutate: markVisited, isPending: isMarkingVisited } = useMarkVisitedMutation();
   const { data: vacancies = [], isLoading: isVacancyLoading } = useMyVacanciesQuery();
   const { mutate: cancelVacancy } = useCancelVacancyMutation();
   const [cancelTarget, setCancelTarget] = useState<number | null>(null);
@@ -390,6 +395,7 @@ export default function ReservationsPage() {
                   reservation={reservation}
                   onCancel={handleCancel}
                   onMarkVisited={handleMarkVisited}
+                  isMarkingVisited={isMarkingVisited}
                   onWriteReview={openReviewModal}
                   onEditReview={openEditReviewModal}
                   isReviewed={reviewedReservationIds.has(reservation.id)}

--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -19,7 +19,7 @@ import BottomSheet from '@/components/common/BottomSheet';
 import Tabs from '@/components/common/Tabs';
 import LoginRequired from '@/components/common/LoginRequired';
 import { formatDate } from '@/lib/utils';
-import { useReservationsQuery, useCancelReservationMutation } from '@/lib/reservationQuery';
+import { useReservationsQuery, useCancelReservationMutation, useMarkVisitedMutation } from '@/lib/reservationQuery';
 import {
   useCreateReviewMutation,
   useMyReviewsQuery,
@@ -48,12 +48,14 @@ const STATUS_CONFIG: Record<
 function ReservationCard({
   reservation,
   onCancel,
+  onMarkVisited,
   onWriteReview,
   onEditReview,
   isReviewed,
 }: {
   reservation: Reservation;
   onCancel: (id: number) => void;
+  onMarkVisited: (id: number) => void;
   onWriteReview: (reservation: Reservation) => void;
   onEditReview: (reservation: Reservation) => void;
   isReviewed: boolean;
@@ -105,23 +107,31 @@ function ReservationCard({
 
       {/* 액션 버튼 */}
       {isUpcoming && (
-        <div className="mt-4 flex gap-2">
+        <div className="mt-4 flex flex-col gap-2">
           <button
-            onClick={() =>
-              router.push(
-              `/stores/${reservation.storeId}?changeFrom=${reservation.id}`
-              )
-            }
-            className="flex-1 rounded-lg border border-blue-200 py-2 text-sm font-medium text-blue-500 hover:bg-blue-50"
+            onClick={() => onMarkVisited(reservation.id)}
+            className="w-full rounded-lg bg-orange-500 py-2 text-sm font-medium text-white hover:bg-orange-600"
           >
-            예약 변경
+            방문 확정
           </button>
-          <button
-            onClick={() => onCancel(reservation.id)}
-            className="flex-1 rounded-lg border border-red-200 py-2 text-sm font-medium text-red-500 hover:bg-red-50"
-          >
-            예약 취소
-          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={() =>
+                router.push(
+                `/stores/${reservation.storeId}?changeFrom=${reservation.id}`
+                )
+              }
+              className="flex-1 rounded-lg border border-blue-200 py-2 text-sm font-medium text-blue-500 hover:bg-blue-50"
+            >
+              예약 변경
+            </button>
+            <button
+              onClick={() => onCancel(reservation.id)}
+              className="flex-1 rounded-lg border border-red-200 py-2 text-sm font-medium text-red-500 hover:bg-red-50"
+            >
+              예약 취소
+            </button>
+          </div>
         </div>
       )}
 
@@ -166,6 +176,7 @@ export default function ReservationsPage() {
   const userId = useAuthStore((s) => s.userId) ?? 0;
   const { data: reservations = [], isLoading } = useReservationsQuery();
   const { mutate: cancelReservation } = useCancelReservationMutation();
+  const { mutate: markVisited } = useMarkVisitedMutation();
   const { data: vacancies = [], isLoading: isVacancyLoading } = useMyVacanciesQuery();
   const { mutate: cancelVacancy } = useCancelVacancyMutation();
   const [cancelTarget, setCancelTarget] = useState<number | null>(null);
@@ -197,6 +208,14 @@ export default function ReservationsPage() {
 
   const handleCancel = (id: number) => {
     setCancelTarget(id);
+  };
+
+  const handleMarkVisited = (id: number) => {
+    markVisited(id, {
+      onSuccess: () => {
+        toast.success('방문 처리되었습니다.');
+      },
+    });
   };
 
   const confirmCancel = () => {
@@ -370,6 +389,7 @@ export default function ReservationsPage() {
                   key={reservation.id}
                   reservation={reservation}
                   onCancel={handleCancel}
+                  onMarkVisited={handleMarkVisited}
                   onWriteReview={openReviewModal}
                   onEditReview={openEditReviewModal}
                   isReviewed={reviewedReservationIds.has(reservation.id)}

--- a/src/lib/reservationApi.ts
+++ b/src/lib/reservationApi.ts
@@ -85,3 +85,11 @@ export const updateReservation = async (
   const response = await api.patch(`/reservations/${reservationId}`, payload);
   return unwrap<Reservation>(response, {} as Reservation);
 };
+
+/**
+ * 사용자가 직접 "방문 확정" 버튼을 눌러 예약을 VISITED 상태로 전환한다.
+ * 백엔드는 CONFIRMED 상태에서만 허용하며 ReservationVisitedEvent로 알림이 자동 발송된다.
+ */
+export const markReservationVisited = async (reservationId: number): Promise<void> => {
+  await api.patch(`/reservations/${reservationId}/visit`);
+};

--- a/src/lib/reservationQuery.ts
+++ b/src/lib/reservationQuery.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/stores/authStore';
-import { createReservation, getReservations, cancelReservation, updateReservation } from './reservationApi';
+import { createReservation, getReservations, cancelReservation, updateReservation, markReservationVisited } from './reservationApi';
 import type { ReservationRequest, ReservationUpdateRequest } from './reservationApi';
 
 const reservationsKey = (userId: number | null) => ['reservations', userId];
@@ -50,6 +50,18 @@ export const useCancelReservationMutation = () => {
 
   return useMutation({
     mutationFn: (reservationId: number) => cancelReservation(reservationId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: reservationsKey(userId) });
+    },
+  });
+};
+
+export const useMarkVisitedMutation = () => {
+  const queryClient = useQueryClient();
+  const userId = useAuthStore((s) => s.userId);
+
+  return useMutation({
+    mutationFn: (reservationId: number) => markReservationVisited(reservationId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: reservationsKey(userId) });
     },


### PR DESCRIPTION
- markReservationVisited API 호출 함수 추가
- useMarkVisitedMutation React Query 훅 추가
- 방문 예정 탭 카드에 [방문 확정] 버튼 + 클릭 핸들러 추가
- 성공 시 토스트 + 예약 목록 자동 새로고침

## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #{44}
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
