### PR TITLE
feat: 프론트엔드 UI 일괄 개선 (#51, #52, #53)

### DIFF
--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -1,17 +1,20 @@
 'use client';
 
-import { Suspense, useEffect, useRef } from 'react';
+import { Suspense, useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { ChevronDown, Check } from 'lucide-react';
 import Header from '@/components/common/Header';
 import BottomNav from '@/components/common/BottomNav';
 import StoreCard from '@/components/store/StoreCard';
 import { useStoresInfiniteQuery } from '@/lib/storeQuery';
-import { STORE_CATEGORIES } from '@/lib/storeEnum';
+import { STORE_CATEGORIES, STORE_DISTRICTS, toDistrictLabel } from '@/lib/storeEnum';
+import { useDragScroll } from '@/hooks/useDragScroll';
 
 function CategoryContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const selectedCategory = searchParams.get('selected'); // 백엔드 enum 값
+  const selectedDistrict = searchParams.get('district');
 
   const {
     data,
@@ -20,7 +23,10 @@ function CategoryContent() {
     hasNextPage,
     isFetchingNextPage,
   } = useStoresInfiniteQuery(
-    { category: selectedCategory ?? undefined },
+    {
+      category: selectedCategory ?? undefined,
+      district: selectedDistrict ?? undefined,
+    },
     10,
   );
 
@@ -42,20 +48,51 @@ function CategoryContent() {
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  const handleCategoryClick = (categoryEnum: string | null) => {
-    if (categoryEnum) {
-      router.push(`/category?selected=${categoryEnum}`);
-    } else {
-      router.push('/category');
-    }
+  const buildHref = (category: string | null, district: string | null) => {
+    const params = new URLSearchParams();
+    if (category) params.set('selected', category);
+    if (district) params.set('district', district);
+    const qs = params.toString();
+    return qs ? `/category?${qs}` : '/category';
   };
+
+  const handleCategoryClick = (categoryEnum: string | null) => {
+    router.push(buildHref(categoryEnum, selectedDistrict));
+  };
+
+  const handleDistrictClick = (districtEnum: string | null) => {
+    router.push(buildHref(selectedCategory, districtEnum));
+    setIsDistrictOpen(false);
+  };
+
+  const categoryScrollRef = useDragScroll<HTMLDivElement>();
+
+  const [isDistrictOpen, setIsDistrictOpen] = useState(false);
+  const districtDropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isDistrictOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        districtDropdownRef.current &&
+        !districtDropdownRef.current.contains(e.target as Node)
+      ) {
+        setIsDistrictOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isDistrictOpen]);
 
   return (
     <>
       <Header showSearch showBack />
       <main className="flex-1">
         {/* 카테고리 탭 */}
-        <div className="flex gap-2 overflow-x-auto border-b border-gray-100 px-4 py-3">
+        <div
+          ref={categoryScrollRef}
+          className="flex gap-2 overflow-x-auto border-b border-gray-100 px-4 py-3 select-none"
+        >
           <button
             onClick={() => handleCategoryClick(null)}
             className={`flex-shrink-0 rounded-full px-4 py-2 text-sm ${
@@ -79,6 +116,55 @@ function CategoryContent() {
               {category.icon} {category.label}
             </button>
           ))}
+        </div>
+
+        {/* 지역 필터 (드롭다운) */}
+        <div className="border-b border-gray-100 px-4 py-3">
+          <div ref={districtDropdownRef} className="relative inline-block">
+            <button
+              onClick={() => setIsDistrictOpen((v) => !v)}
+              className={`flex items-center gap-1 rounded-full px-4 py-2 text-sm ${
+                selectedDistrict
+                  ? 'bg-orange-500 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors'
+              }`}
+            >
+              <span>{selectedDistrict ? toDistrictLabel(selectedDistrict) : '지역 선택'}</span>
+              <ChevronDown
+                size={16}
+                className={`transition-transform ${isDistrictOpen ? 'rotate-180' : ''}`}
+              />
+            </button>
+
+            {isDistrictOpen && (
+              <div className="absolute left-0 top-full z-20 mt-2 max-h-72 w-44 overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg">
+                <button
+                  onClick={() => handleDistrictClick(null)}
+                  className={`flex w-full items-center justify-between px-4 py-2.5 text-left text-sm hover:bg-gray-50 ${
+                    selectedDistrict === null ? 'font-semibold text-orange-500' : 'text-gray-700'
+                  }`}
+                >
+                  <span>전체 지역</span>
+                  {selectedDistrict === null && <Check size={16} className="text-orange-500" />}
+                </button>
+                {STORE_DISTRICTS.map((district) => {
+                  const isActive = selectedDistrict === district.enumValue;
+                  return (
+                    <button
+                      key={district.enumValue}
+                      onClick={() => handleDistrictClick(district.enumValue)}
+                      className={`flex w-full items-center justify-between px-4 py-2.5 text-left text-sm hover:bg-gray-50 ${
+                        isActive ? 'font-semibold text-orange-500' : 'text-gray-700'
+                      }`}
+                    >
+                      <span>{district.label}</span>
+                      {isActive && <Check size={16} className="text-orange-500" />}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
         </div>
 
         {/* 매장 목록 */}

--- a/src/app/stores/[id]/page.tsx
+++ b/src/app/stores/[id]/page.tsx
@@ -409,13 +409,11 @@ export default function StoreDetail() {
               isSelectedFullyBooked ? 'bg-blue-500 hover:bg-blue-600' : 'bg-orange-500 hover:bg-orange-600'
             }`}
           >
-            {slotState === 'unknown'
-              ? (isSelectedFullyBooked ? '시간대 선택하고 빈자리 알림 받기' : '예약하기')
-              : slotState === 'mixed'
-                ? '예약 또는 빈자리 알림'
-                : slotState === 'vacancy'
-                  ? '시간대 선택하고 빈자리 알림 받기'
-                  : '예약하기'}
+            {slotState === 'mixed'
+              ? '예약 또는 빈자리 알림'
+              : (slotState === 'vacancy' || (slotState === 'unknown' && isSelectedFullyBooked))
+                ? '시간대 선택하고 빈자리 알림 받기'
+                : '예약하기'}
           </button>
         )}
       </div>

--- a/src/app/stores/[id]/page.tsx
+++ b/src/app/stores/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, Fragment } from 'react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
-import { Star, Clock, MapPin, Heart, Check, Plus } from 'lucide-react';
+import { Star, Clock, MapPin, Heart, Check, Plus, Bell } from 'lucide-react';
 import { DayPicker } from 'react-day-picker';
 import { ko } from 'react-day-picker/locale';
 import 'react-day-picker/style.css';
@@ -15,6 +15,7 @@ import FolderFormModal from '@/components/common/FolderFormModal';
 import type { StoreRemain } from '@/types/store';
 import { useStoreDetailQuery, useStoreMenusQuery, useStoreReviewsQuery, useStoreTimesQuery } from '@/lib/storeQuery';
 import { useCreateVacancyMutation } from '@/lib/vacancyQuery';
+import { useDragScroll } from '@/hooks/useDragScroll';
 import {
   useBookmarkFoldersQuery,
   useCreateBookmarkFolderMutation,
@@ -49,6 +50,7 @@ export default function StoreDetail() {
   const { data: menus = [], isLoading: isMenuLoading } = useStoreMenusQuery(id);
   const { data: reviews = [], isLoading: isReviewLoading } = useStoreReviewsQuery(id);
   const { mutate: createVacancy, isPending: isVacancyPending } = useCreateVacancyMutation();
+  const dateStripRef = useDragScroll<HTMLDivElement>();
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [selectedTime, setSelectedTime] = useState<string | null>(null);
   const [selectedRemainId, setSelectedRemainId] = useState<number | null>(null);
@@ -100,6 +102,17 @@ export default function StoreDetail() {
     days.map(d => d.toDateString()).filter(dStr => store?.remainDates ? !availableDates.has(dStr) : false)
   );
   const isSelectedFullyBooked = fullyBookedDates.has(selectedDate.toDateString());
+
+  const hasAvailableSlot = times.some((t) => t.remainTeam > 0);
+  const hasFullSlot = times.some((t) => t.remainTeam <= 0);
+  const slotState: 'mixed' | 'reserve' | 'vacancy' | 'unknown' =
+    times.length === 0
+      ? 'unknown'
+      : hasAvailableSlot && hasFullSlot
+        ? 'mixed'
+        : hasAvailableSlot
+          ? 'reserve'
+          : 'vacancy';
 
   if (!id || isLoading) {
     return (
@@ -235,7 +248,7 @@ export default function StoreDetail() {
               휴업중인 매장은 예약이 불가합니다.
             </p>
           ) : (
-            <div className="flex gap-2 overflow-x-auto">
+            <div ref={dateStripRef} className="flex gap-2 overflow-x-auto select-none">
               {days.map((date) => {
                 const { month, day, weekday } = formatDateParts(date);
                 const isToday =
@@ -396,7 +409,13 @@ export default function StoreDetail() {
               isSelectedFullyBooked ? 'bg-blue-500 hover:bg-blue-600' : 'bg-orange-500 hover:bg-orange-600'
             }`}
           >
-            {isSelectedFullyBooked ? '시간대 선택하고 빈자리 알림 받기' : '예약하기'}
+            {slotState === 'unknown'
+              ? (isSelectedFullyBooked ? '시간대 선택하고 빈자리 알림 받기' : '예약하기')
+              : slotState === 'mixed'
+                ? '예약 또는 빈자리 알림'
+                : slotState === 'vacancy'
+                  ? '시간대 선택하고 빈자리 알림 받기'
+                  : '예약하기'}
           </button>
         )}
       </div>
@@ -442,8 +461,12 @@ export default function StoreDetail() {
             {/* 시간 선택 */}
             <div className="mb-5 mt-2">
               <p className="mb-2 px-1 text-base font-medium text-gray-700">
-                {selectedDate.getMonth() + 1}월 {selectedDate.getDate()}일 예약
-                가능 시간
+                {selectedDate.getMonth() + 1}월 {selectedDate.getDate()}일{' '}
+                {slotState === 'mixed'
+                  ? '예약 또는 빈자리 알림'
+                  : slotState === 'vacancy'
+                    ? '빈자리 알림 받을 시간'
+                    : '예약 가능 시간'}
               </p>
               <div className="grid grid-cols-5 gap-2">
                 {isTimesLoading ? (
@@ -462,14 +485,15 @@ export default function StoreDetail() {
                           setSelectedTimeIsFull(isFull);
                         }
                       }}
-                      className={`rounded-lg border py-2 text-sm font-medium ${
+                      className={`flex items-center justify-center gap-1 rounded-lg border py-2 text-sm font-medium ${
                         selectedTime === displayTime
                           ? selectedTimeIsFull ? 'border-blue-500 bg-blue-50 text-blue-500' : 'border-orange-500 bg-orange-50 text-orange-500'
                           : isFull
-                          ? 'border-gray-100 bg-gray-50 text-gray-400'
+                          ? 'border-dashed border-gray-300 text-gray-600 hover:border-blue-500 hover:text-blue-500'
                           : 'border-gray-200 text-gray-700 hover:border-orange-500 hover:text-orange-500'
                       }`}
                     >
+                      {isFull && <Bell size={12} />}
                       {displayTime}
                     </button>
                     );

--- a/src/hooks/useDragScroll.ts
+++ b/src/hooks/useDragScroll.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export function useDragScroll<T extends HTMLElement>() {
+  const [node, setNode] = useState<T | null>(null);
+
+  const ref = useCallback((el: T | null) => {
+    setNode(el);
+  }, []);
+
+  useEffect(() => {
+    const el = node;
+    if (!el) return;
+
+    let isDown = false;
+    let startX = 0;
+    let scrollLeftStart = 0;
+    let hasMoved = false;
+
+    const onMouseDown = (e: MouseEvent) => {
+      isDown = true;
+      hasMoved = false;
+      startX = e.pageX - el.offsetLeft;
+      scrollLeftStart = el.scrollLeft;
+      el.style.cursor = 'grabbing';
+    };
+
+    const stopDrag = () => {
+      isDown = false;
+      el.style.cursor = 'grab';
+    };
+
+    const onMouseMove = (e: MouseEvent) => {
+      if (!isDown) return;
+      const x = e.pageX - el.offsetLeft;
+      const walk = x - startX;
+      if (Math.abs(walk) > 5) hasMoved = true;
+      if (hasMoved) {
+        e.preventDefault();
+        el.scrollLeft = scrollLeftStart - walk;
+      }
+    };
+
+    const onClickCapture = (e: MouseEvent) => {
+      if (hasMoved) {
+        e.preventDefault();
+        e.stopPropagation();
+        hasMoved = false;
+      }
+    };
+
+    el.style.cursor = 'grab';
+    el.addEventListener('mousedown', onMouseDown);
+    el.addEventListener('mouseleave', stopDrag);
+    el.addEventListener('mouseup', stopDrag);
+    el.addEventListener('mousemove', onMouseMove);
+    el.addEventListener('click', onClickCapture, true);
+
+    return () => {
+      el.removeEventListener('mousedown', onMouseDown);
+      el.removeEventListener('mouseleave', stopDrag);
+      el.removeEventListener('mouseup', stopDrag);
+      el.removeEventListener('mousemove', onMouseMove);
+      el.removeEventListener('click', onClickCapture, true);
+    };
+  }, [node]);
+
+  return ref;
+}

--- a/src/hooks/useDragScroll.ts
+++ b/src/hooks/useDragScroll.ts
@@ -19,7 +19,7 @@ export function useDragScroll<T extends HTMLElement>() {
     const onMouseDown = (e: MouseEvent) => {
       isDown = true;
       hasMoved = false;
-      startX = e.pageX - el.offsetLeft;
+      startX = e.pageX;
       scrollLeftStart = el.scrollLeft;
       el.style.cursor = 'grabbing';
     };
@@ -31,7 +31,7 @@ export function useDragScroll<T extends HTMLElement>() {
 
     const onMouseMove = (e: MouseEvent) => {
       if (!isDown) return;
-      const x = e.pageX - el.offsetLeft;
+      const x = e.pageX;
       const walk = x - startX;
       if (Math.abs(walk) > 5) hasMoved = true;
       if (hasMoved) {


### PR DESCRIPTION
## 📢 기능 설명
백엔드는 지원하지만 프론트에서 노출되지 않던 기능들을 추가하고,
가로 스크롤 UX 개선을 위한 드래그 스크롤을 도입.

- 빈자리 알림 시간대 선택 UI 추가 (#51) 매장 상세에서 시간 슬롯 상태에 따라 진입 버튼/모달 헤더를 3-way로 분기, 만석 슬롯에 점선 테두리 + 종 아이콘 적용

- 카테고리 페이지 지역 필터 드롭다운 추가 (#52) 25개 서울 자치구 드롭다운 추가, 카테고리와 독립 동작, URL 파라미터 동기화

- 가로 드래그 스크롤 기능 추가 (#53) useDragScroll 커스텀 훅으로 마우스 클릭+드래그 스크롤 지원, 카테고리 탭과 14일 날짜 스트립에 적용

필요시 실행결과 스크린샷 첨부
<br>
<img width="591" height="862" alt="예약 또는 빈자리 알림" src="https://github.com/user-attachments/assets/711e38be-f003-4610-83f0-7b02ad068ef4" />
<img width="605" height="857" alt="예약하기" src="https://github.com/user-attachments/assets/a28e2f85-0c84-4931-a08e-1667be77457c" />
<img width="602" height="867" alt="빈자리알림받을시간선택" src="https://github.com/user-attachments/assets/56de0fed-86c7-4868-8651-1d025ac50a3d" />
<img width="605" height="857" alt="빈자리 알림 시간대 등록" src="https://github.com/user-attachments/assets/4d8f78ac-7a0b-449f-a97f-79edb9259af6" />
<img width="607" height="857" alt="결과" src="https://github.com/user-attachments/assets/54e08e51-2668-410c-a835-99d9cd1f29fa" />

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #51
close #52
close #53
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
